### PR TITLE
Ensure process discovery outputs are saved to existing media paths

### DIFF
--- a/pmt/core/pm4py_discovery.py
+++ b/pmt/core/pm4py_discovery.py
@@ -1,5 +1,6 @@
 # Data Handling libraries
 import pm4py
+from pathlib import Path
 from django.conf import settings
 
 # Alpha miner imports
@@ -27,40 +28,50 @@ def process_model_discovery(event_log_name, process_model_name):
     # Import event log
     event_log = EventLog.objects.get(event_log_name=event_log_name)
     event_log_path = event_log.event_log_file
-    event_log_file = xes_importer.apply("media/" + str(event_log_path))
+    event_log_file = xes_importer.apply(Path(settings.MEDIA_ROOT) / str(event_log_path))
 
     if event_log is None or event_log_path is None or event_log_file is None:
         return False
 
     # Discover petri net using inductive miner and save it
     net, im, fm = inductive_miner.apply(event_log_file)
-    petri_net_path = "media/process_models/pnml/" + process_model_name + ".pnml"
-    pnml_exporter.apply(net, im, petri_net_path, final_marking=fm)
+    media_root = Path(settings.MEDIA_ROOT)
+
+    petri_net_dir = media_root / "process_models" / "pnml"
+    bpmn_dir = media_root / "process_models" / "bpmn"
+    petri_png_dir = media_root / "exported_pngs" / "pnml"
+    bpmn_png_dir = media_root / "exported_pngs" / "bpmn"
+
+    for directory in (petri_net_dir, bpmn_dir, petri_png_dir, bpmn_png_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    petri_net_path = petri_net_dir / f"{process_model_name}.pnml"
+    pnml_exporter.apply(net, im, str(petri_net_path), final_marking=fm)
     # Convert petri into process tree
     tree = wf_net_converter.apply(net, im, fm)
     # Convert process tree into bpmn and save it
     bpmn_graph = pt_converter.apply(tree, variant=pt_converter.Variants.TO_BPMN)
-    bpmn_path = "media/process_models/bpmn/" + process_model_name + ".bpmn"
-    bpmn_exporter.apply(bpmn_graph, bpmn_path)
+    bpmn_path = bpmn_dir / f"{process_model_name}.bpmn"
+    bpmn_exporter.apply(bpmn_graph, str(bpmn_path))
     # Export petri net png
     petri_net_gviz = pn_visualizer.apply(net, im, fm)
-    petri_net_png_path = "media/exported_pngs/pnml/" + process_model_name + ".png"
-    pn_visualizer.save(petri_net_gviz, output_file_path=petri_net_png_path)
+    petri_net_png_path = petri_png_dir / f"{process_model_name}.png"
+    pn_visualizer.save(petri_net_gviz, output_file_path=str(petri_net_png_path))
     # Export bpmn png
     bpmn_graph_gviz = bpmn_visualizer.apply(bpmn_graph)
-    bpmn_png_path = "media/exported_pngs/bpmn/" + process_model_name + ".png"
-    bpmn_visualizer.save(bpmn_graph_gviz, output_file_path=bpmn_png_path)
+    bpmn_png_path = bpmn_png_dir / f"{process_model_name}.png"
+    bpmn_visualizer.save(bpmn_graph_gviz, output_file_path=str(bpmn_png_path))
     # Export Petri net png with frequency
     petri_net_frequency_gviz = pn_visualizer.apply(net, im, fm, parameters={
         pn_visualizer.Variants.FREQUENCY.value.Parameters.FORMAT: "png"},
                                                    variant=pn_visualizer.Variants.FREQUENCY, log=event_log_file)
-    petri_net_frequency_png_path = "media/exported_pngs/pnml/" + process_model_name + "_frequency.png"
-    pn_visualizer.save(petri_net_frequency_gviz, output_file_path=petri_net_frequency_png_path)
+    petri_net_frequency_png_path = petri_png_dir / f"{process_model_name}_frequency.png"
+    pn_visualizer.save(petri_net_frequency_gviz, output_file_path=str(petri_net_frequency_png_path))
     # Export Petri net png with performance
     petri_net_performance_gviz = pn_visualizer.apply(net, im, fm, parameters={
         pn_visualizer.Variants.PERFORMANCE.value.Parameters.FORMAT: "png"},
                                                      variant=pn_visualizer.Variants.PERFORMANCE, log=event_log_file)
-    petri_net_performance_png_path = "media/exported_pngs/pnml/" + process_model_name + "_performance.png"
-    pn_visualizer.save(petri_net_performance_gviz, output_file_path=petri_net_performance_png_path)
+    petri_net_performance_png_path = petri_png_dir / f"{process_model_name}_performance.png"
+    pn_visualizer.save(petri_net_performance_gviz, output_file_path=str(petri_net_performance_png_path))
 
     return True


### PR DESCRIPTION
## Summary
- ensure process discovery uses MEDIA_ROOT when reading logs
- create required media subdirectories before exporting artifacts
- save exported models and images using pathlib-managed paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6029ecd648328ba2c0e80a52aa631